### PR TITLE
Fixup Multiple Analyzer Conventions

### DIFF
--- a/WoofWare.FSharpAnalyzers/WoofWare.FSharpAnalyzers.fsproj
+++ b/WoofWare.FSharpAnalyzers/WoofWare.FSharpAnalyzers.fsproj
@@ -4,6 +4,10 @@
     <TargetFramework>net8.0</TargetFramework>
     <!-- https://learn.microsoft.com/en-us/nuget/reference/msbuild-targets#pack-target-inputs -->
     <DevelopmentDependency>true</DevelopmentDependency>
+    <NoPackageAnalysis>true</NoPackageAnalysis>
+    <TargetsForTfmSpecificContentInPackage>$(TargetsForTfmSpecificContentInPackage);_AddAnalyzersToOutput</TargetsForTfmSpecificContentInPackage>
+    <IncludeBuildOutput>false</IncludeBuildOutput>
+    <SuppressDependenciesWhenPacking>true</SuppressDependenciesWhenPacking>
     <Description>Opinionated F# source analyzers</Description>
     <Authors>PatrickStevens</Authors>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
@@ -39,4 +43,10 @@
     <PackageReference Include="FSharp.Analyzers.SDK" Version="0.32.1" />
   </ItemGroup>
 
+    <Target Name="_AddAnalyzersToOutput">
+    <ItemGroup>
+      <TfmSpecificPackageFile Include="$(OutputPath)\$(AssemblyName).dll" PackagePath="analyzers/dotnet/fs" />
+    </ItemGroup>
+
+  </Target>
 </Project>


### PR DESCRIPTION
👋 I tried using this today but I noticed a few things were missing

- Adds `fsharp-analyzer`. Makes it easier to look up on using the same specific tag: https://www.nuget.org/packages?q=Tags%3A%22fsharp-analyzer%22
- Adds the dll to the `analyzers/dotnet/fs` [path convention](https://learn.microsoft.com/en-us/nuget/guides/analyzers-conventions#analyzers-path-format)
- Removes direct dependencies
    - This makes it so the project referencing this package won't get NU1202 errors, meaning it doesn't have to be on net8.0 (or whatever TFM this analyzer was built with). 
    - Otherwise, NuGet will give errors like `IcedTasks.fsproj : error NU1202: Package WoofWare.FSharpAnalyzers 0.1.3 is not compatible with net6.0 (.NETCoreApp,Version=v6.0). Package WoofWare.FSharpAnalyzers 0.1.3 supports: net8.0 (.NETCoreApp,Version=v8.0)` where as it shouldn't matter what the project's TFM is.
    
---

The new nuspec looks like:
    
    
```xml
<?xml version="1.0" encoding="utf-8"?>
<package xmlns="http://schemas.microsoft.com/packaging/2011/10/nuspec.xsd">
  <metadata>
    <id>WoofWare.FSharpAnalyzers</id>
    <version>0.1.4-g733b65b7c1</version>
    <authors>PatrickStevens</authors>
    <developmentDependency>true</developmentDependency>
    <license type="expression">MIT</license>
    <licenseUrl>https://licenses.nuget.org/MIT</licenseUrl>
    <readme>README.md</readme>
    <description>Opinionated F# source analyzers</description>
    <copyright>Copyright (c) Patrick Stevens 2025</copyright>
    <tags>fsharp analyzers fsharp-analyzer</tags>
    <repository type="git" url="https://github.com/Smaug123/WoofWare.FSharpAnalyzers" commit="733b65b7c12ee3744bf42bb22264a37e956cd44a" />
  </metadata>
</package>
```