### PR TITLE
Detect blocking GetResult on configured awaiters

### DIFF
--- a/WoofWare.FSharpAnalyzers.Test/Data/BlockingCallsAnalyzer/positive/ConfigureAwait.fs
+++ b/WoofWare.FSharpAnalyzers.Test/Data/BlockingCallsAnalyzer/positive/ConfigureAwait.fs
@@ -1,0 +1,19 @@
+module ConfigureAwaitGetResult
+
+open System.Threading.Tasks
+
+let testTaskConfigureAwait () =
+    let t = Task.Run (fun () -> ())
+    t.ConfigureAwait(false).GetAwaiter().GetResult ()
+
+let testTaskConfigureAwaitGeneric () =
+    let t = Task.Run (fun () -> 42)
+    t.ConfigureAwait(false).GetAwaiter().GetResult ()
+
+let testValueTaskConfigureAwait () =
+    let vt = ValueTask (Task.CompletedTask)
+    vt.ConfigureAwait(false).GetAwaiter().GetResult ()
+
+let testValueTaskConfigureAwaitGeneric () =
+    let vt = ValueTask<string> ("hello")
+    vt.ConfigureAwait(false).GetAwaiter().GetResult ()

--- a/WoofWare.FSharpAnalyzers.Test/Data/BlockingCallsAnalyzer/positive/ConfigureAwait.fs.expected
+++ b/WoofWare.FSharpAnalyzers.Test/Data/BlockingCallsAnalyzer/positive/ConfigureAwait.fs.expected
@@ -1,0 +1,4 @@
+WOOF-BLOCKING | Warning | (7,4--7,53) | Synchronous blocking call 'ConfiguredTaskAwaiter.GetResult' should be avoided. This can cause deadlocks and thread pool starvation. Consider using `let!` in a `task` or `async` computation expression.
+WOOF-BLOCKING | Warning | (11,4--11,53) | Synchronous blocking call 'ConfiguredTaskAwaiter.GetResult' should be avoided. This can cause deadlocks and thread pool starvation. Consider using `let!` in a `task` or `async` computation expression.
+WOOF-BLOCKING | Warning | (15,4--15,54) | Synchronous blocking call 'ConfiguredValueTaskAwaiter.GetResult' should be avoided. This can cause deadlocks and thread pool starvation. Consider using `let!` in a `task` or `async` computation expression.
+WOOF-BLOCKING | Warning | (19,4--19,54) | Synchronous blocking call 'ConfiguredValueTaskAwaiter.GetResult' should be avoided. This can cause deadlocks and thread pool starvation. Consider using `let!` in a `task` or `async` computation expression.

--- a/WoofWare.FSharpAnalyzers/BlockingCallsAnalyzer.fs
+++ b/WoofWare.FSharpAnalyzers/BlockingCallsAnalyzer.fs
@@ -24,6 +24,11 @@ module BlockingCallsAnalyzer =
             "System.Runtime.CompilerServices.TaskAwaiter`1.GetResult"
             "System.Runtime.CompilerServices.ValueTaskAwaiter.GetResult"
             "System.Runtime.CompilerServices.ValueTaskAwaiter`1.GetResult"
+            // Configured awaiters, produced by `.ConfigureAwait(...)`
+            "System.Runtime.CompilerServices.ConfiguredTaskAwaitable.ConfiguredTaskAwaiter.GetResult"
+            "System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1.ConfiguredTaskAwaiter.GetResult"
+            "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable.ConfiguredValueTaskAwaiter.GetResult"
+            "System.Runtime.CompilerServices.ConfiguredValueTaskAwaitable`1.ConfiguredValueTaskAwaiter.GetResult"
         ]
         |> Set.ofList
 


### PR DESCRIPTION
## Problem

`task.ConfigureAwait(false).GetAwaiter().GetResult()` produced no `WOOF-BLOCKING` diagnostic. `.ConfigureAwait(...)` returns a `Configured*Awaitable` struct whose `.GetAwaiter().GetResult()` is a distinct awaiter type from the plain `TaskAwaiter`/`ValueTaskAwaiter` that `BlockingCallsAnalyzer.problematicMethods` matched, so this common sync-over-async form slipped through.

## Fix

Add the four configured-awaiter `GetResult` FullNames (non-generic and generic, for both `Task` and `ValueTask`) to the problematic-methods set. The exact TAST FullNames were confirmed empirically via the `getTast` helper. The existing message-formatting logic already yields sensible messages (`ConfiguredTaskAwaiter.GetResult` / `ConfiguredValueTaskAwaiter.GetResult`) with no other changes.

## Tests

Added a positive test (`Data/BlockingCallsAnalyzer/positive/ConfigureAwait.fs`) covering all four shapes; its `.expected` shows all four diagnostics. Full suite passes (103 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)